### PR TITLE
fix(localization): make status bar countdown string localizable

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -83,10 +83,15 @@ msgstr "فشل تحديد الموقع تلقائيًا. سيتم الاعتما
 msgid "Time for %s"
 msgstr "حان وقت %s"
 
-#: src/extension.js:189
+#: src/extension.js:177
 #, javascript-format
 msgid "%s in %d minutes"
 msgstr "%s خلال %d دقيقة"
+
+#: src/extension.js:186
+#, javascript-format
+msgid "%s in %s"
+msgstr "%s بعد %s"
 
 #: src/mawaqit-client.js:46
 #, javascript-format

--- a/po/prayertimes@mocab.guide.pot
+++ b/po/prayertimes@mocab.guide.pot
@@ -84,9 +84,14 @@ msgstr ""
 msgid "Time for %s"
 msgstr ""
 
-#: src/extension.js:189
+#: src/extension.js:177
 #, javascript-format
 msgid "%s in %d minutes"
+msgstr ""
+
+#: src/extension.js:186
+#, javascript-format
+msgid "%s in %s"
 msgstr ""
 
 #: src/mawaqit-client.js:46

--- a/src/extension.js
+++ b/src/extension.js
@@ -180,9 +180,10 @@ export default class PrayerTime extends Extension {
             return;
         }
 
+        const formattedTime = `${String((minutesLeft / 60) | 0).padStart(2, "0")}:${String(minutesLeft % 60).padStart(2, "0")}`;
         this._indicator.text =
             this._settings.displayMode === "countdown"
-                ? `${nextPrayer.name} in ${String((minutesLeft / 60) | 0).padStart(2, "0")}:${String(minutesLeft % 60).padStart(2, "0")}` // | 0 same as Math.floor when x > 0
+                ? _("%s in %s").format(nextPrayer.name, formattedTime)
                 : `${nextPrayer.name} - ${nextPrayer.time.format(this._timeFormat)}`;
     }
     async _advanceToNextDay() {

--- a/src/extension.js
+++ b/src/extension.js
@@ -180,10 +180,9 @@ export default class PrayerTime extends Extension {
             return;
         }
 
-        const formattedTime = `${String((minutesLeft / 60) | 0).padStart(2, "0")}:${String(minutesLeft % 60).padStart(2, "0")}`;
         this._indicator.text =
-            this._settings.displayMode === "countdown"
-                ? _("%s in %s").format(nextPrayer.name, formattedTime)
+            this._settings.displayMode === "countdown" //
+                ? _("%s in %s").format(nextPrayer.name, `${String((minutesLeft / 60) | 0).padStart(2, "0")}:${String(minutesLeft % 60).padStart(2, "0")}`)
                 : `${nextPrayer.name} - ${nextPrayer.time.format(this._timeFormat)}`;
     }
     async _advanceToNextDay() {


### PR DESCRIPTION
### Summary
Fixes the countdown display in non-English locales (specifically Arabic) where the word 'in' was hardcoded in English.

### Changes
- **Localizable String**: Wrapped countdown format in `_("%s in %s")` using gettext in `src/extension.js`.
- **POT Template**: Added `msgid "%s in %s"` to `po/prayertimes@mocab.guide.pot`.
- **Arabic Translation**: Added `msgstr "%s بعد %s"` in `po/ar.po`.